### PR TITLE
4コースとREADME実装#5

### DIFF
--- a/src/counter.js
+++ b/src/counter.js
@@ -1,9 +1,0 @@
-export function setupCounter(element) {
-  let counter = 0
-  const setCounter = (count) => {
-    counter = count
-    element.innerHTML = `count is ${counter}`
-  }
-  element.addEventListener('click', () => setCounter(counter + 1))
-  setCounter(0)
-}

--- a/src/game/courses.js
+++ b/src/game/courses.js
@@ -1,0 +1,74 @@
+export const COURSES = {
+  ground: {
+    name: "地上コース",
+    theme: "ground",
+    screens: 4,
+    worldHeight: 600,
+    bg: 0x87ceeb,
+    gravityY: 1100,
+    player: { accel: 450, maxVX: 180, jumpVY: -520 },
+    goal: { x: 0.88 },
+    platforms: [
+      { x: 0.3, y: 0.75, w: 4 },
+      { x: 0.55, y: 0.65, w: 3 },
+    ],
+    hazards: [],
+  },
+
+  underground: {
+    name: "地下コース",
+    theme: "underground",
+    screens: 4,
+    worldHeight: 600,
+    bg: 0x2b1b14,
+    gravityY: 1200,
+    player: { accel: 420, maxVX: 170, jumpVY: -500 },
+    goal: { x: 0.88 },
+    platforms: [
+      { x: 0.25, y: 0.72, w: 4 },
+      { x: 0.45, y: 0.58, w: 3 },
+      { x: 0.7, y: 0.68, w: 3 },
+    ],
+    overlay: { alpha: 0.3 },
+    hazards: [],
+  },
+
+  underwater: {
+    name: "水中コース",
+    theme: "underwater",
+    screens: 4,
+    worldHeight: 600,
+    bg: 0x1e90ff,
+    gravityY: 200,
+    player: { accel: 260, maxVX: 130, jumpVY: -200 },
+    swim: {
+      buoyancy: -80,
+      upThrust: -700,
+      downThrust: 350,
+      maxVY: 300,
+    },
+    goal: { x: 0.88 },
+    platforms: [
+      { x: 0.3, y: 0.6, w: 3 },
+      { x: 0.55, y: 0.5, w: 3 },
+    ],
+    hazards: [],
+  },
+
+  castle: {
+    name: "城（マグマ）コース",
+    theme: "castle",
+    screens: 5,
+    worldHeight: 600,
+    bg: 0x141414,
+    gravityY: 1100,
+    player: { accel: 470, maxVX: 185, jumpVY: -520 },
+    goal: { x: 0.9 },
+    platforms: [
+      { x: 0.25, y: 0.65, w: 3 },
+      { x: 0.45, y: 0.55, w: 2 },
+      { x: 0.65, y: 0.6, w: 3 },
+    ],
+    hazards: [{ type: "lava", y: 0.96, h: 0.08 }],
+  },
+};

--- a/src/game/scenes/ClearScene.js
+++ b/src/game/scenes/ClearScene.js
@@ -1,0 +1,21 @@
+export class ClearScene extends Phaser.Scene {
+  constructor() {
+    super("clear");
+  }
+
+  create() {
+    this.cameras.main.setBackgroundColor("#065f46");
+
+    this.add.text(40, 120, "CLEAR!!", {
+      fontSize: "48px",
+      color: "#fff",
+    });
+
+    this.add.text(40, 220, "クリックでメニューへ", {
+      fontSize: "20px",
+      color: "#fff",
+    }).setInteractive().on("pointerdown", () => {
+      this.scene.start("menu");
+    });
+  }
+}

--- a/src/game/scenes/GameScene.js
+++ b/src/game/scenes/GameScene.js
@@ -1,0 +1,147 @@
+import Phaser from "phaser";
+import { COURSES } from "../courses.js";
+import { makeRectTexture } from "../utils/textures.js";
+
+export class GameScene extends Phaser.Scene {
+  constructor() {
+    super("game");
+  }
+
+  init(data) {
+    this.courseKey = data.courseKey ?? "ground";
+    this.course = COURSES[this.courseKey];
+  }
+
+  create() {
+    const screenW = this.scale.width;
+    this.worldW = screenW * this.course.screens;
+    this.worldH = this.course.worldHeight;
+
+    this.physics.world.setBounds(0, 0, this.worldW, this.worldH);
+    this.cameras.main.setBounds(0, 0, this.worldW, this.worldH);
+    this.cameras.main.setBackgroundColor(this.course.bg);
+
+    makeRectTexture(this, "ground", 64, 24, this.pickGroundColor());
+    makeRectTexture(this, "player", 24, 32, this.pickPlayerColor());
+    makeRectTexture(this, "goal", 28, 60, 0xf59e0b);
+    makeRectTexture(this, "lava", 64, 64, 0xff3300);
+
+    this.physics.world.gravity.y = this.course.gravityY;
+
+    this.platforms = this.physics.add.staticGroup();
+
+    const groundY = this.worldH - 40;
+    this.platforms.create(this.worldW / 2, groundY, "ground")
+      .setScale(this.worldW / 64, 1)
+      .refreshBody();
+
+    for (const p of this.course.platforms ?? []) {
+      this.platforms.create(
+        p.x * this.worldW,
+        p.y * this.worldH,
+        "ground"
+      ).setScale(p.w, 1).refreshBody();
+    }
+
+    const ps = this.course.player;
+    this.accel = ps.accel;
+    this.jumpVY = ps.jumpVY;
+
+    const startY = groundY - 80;
+    this.player = this.physics.add.sprite(120, startY, "player");
+    this.player.setCollideWorldBounds(true);
+    this.player.setMaxVelocity(ps.maxVX, 900);
+
+    this.physics.add.collider(this.player, this.platforms);
+
+    this.cameras.main.startFollow(this.player, true, 1, 1);
+    this.cameras.main.roundPixels = true;
+
+    this.cursors = this.input.keyboard.createCursorKeys();
+    this.input.keyboard.on("keydown-ESC", () => this.scene.start("menu"));
+
+    const goalX = (this.course.goal?.x ?? 0.88) * this.worldW;
+    this.goal = this.physics.add.staticImage(goalX, this.worldH - 70, "goal");
+    this.physics.add.overlap(this.player, this.goal, () => {
+      this.scene.start("clear", { courseKey: this.courseKey });
+    });
+
+    this.hazards = this.physics.add.staticGroup();
+    for (const h of this.course.hazards ?? []) {
+      if (h.type === "lava") {
+        const y = h.y * this.worldH;
+        const hgt = h.h * this.worldH;
+
+        this.add.rectangle(this.worldW / 2, y, this.worldW, hgt, 0xff3300);
+
+        const lava = this.hazards.create(this.worldW / 2, y, "lava");
+        lava.setVisible(false);
+        lava.setScale(this.worldW / 64, hgt / 64).refreshBody();
+      }
+    }
+
+    let safety = 0;
+    while (this.physics.overlap(this.player, this.hazards) && safety < 10) {
+      this.player.y -= 40;
+      this.player.body.updateFromGameObject();
+      safety++;
+    }
+
+    this.physics.add.overlap(this.player, this.hazards, () => {
+      this.scene.restart({ courseKey: this.courseKey });
+    });
+  }
+
+  update() {
+    const isUnderwater = this.course.theme === "underwater";
+
+    if (this.cursors.left.isDown) {
+      this.player.setDragX(0);
+      this.player.setAccelerationX(-this.accel);
+    } else if (this.cursors.right.isDown) {
+      this.player.setDragX(0);
+      this.player.setAccelerationX(this.accel);
+    } else {
+      this.player.setAccelerationX(0);
+      this.player.setDragX(isUnderwater ? 600 : 1400);
+    }
+
+    if (isUnderwater && this.course.swim) {
+      const s = this.course.swim;
+      this.player.setMaxVelocity(this.course.player.maxVX, s.maxVY);
+
+      if (this.cursors.up.isDown) {
+        this.player.setAccelerationY(s.upThrust);
+      } else if (this.cursors.down.isDown) {
+        this.player.setAccelerationY(s.downThrust);
+      } else {
+        this.player.setAccelerationY(s.buoyancy);
+      }
+      return;
+    }
+
+    this.player.setAccelerationY(0);
+    const onGround = this.player.body.blocked.down || this.player.body.touching.down;
+    if (onGround && Phaser.Input.Keyboard.JustDown(this.cursors.up)) {
+      this.player.setVelocityY(this.jumpVY);
+    }
+  }
+
+  pickGroundColor() {
+    switch (this.course.theme) {
+      case "underground": return 0x6b4a2f;
+      case "underwater": return 0x1fb6ff;
+      case "castle": return 0x3f3f46;
+      default: return 0x2ecc71;
+    }
+  }
+
+  pickPlayerColor() {
+    switch (this.course.theme) {
+      case "underground": return 0xa78bfa;
+      case "underwater": return 0x22c55e;
+      case "castle": return 0xf43f5e;
+      default: return 0x2d7ff9;
+    }
+  }
+}

--- a/src/game/scenes/MenuScene.js
+++ b/src/game/scenes/MenuScene.js
@@ -1,0 +1,24 @@
+import { COURSES } from "../courses.js";
+
+export class MenuScene extends Phaser.Scene {
+  constructor() {
+    super("menu");
+  }
+
+  create() {
+    this.cameras.main.setBackgroundColor("#111827");
+
+    let y = 120;
+    for (const key in COURSES) {
+      const btn = this.add.text(40, y, `▶ ${COURSES[key].name}`, {
+        fontSize: "24px",
+        color: "#fff",
+        backgroundColor: "rgba(255,255,255,0.2)",
+        padding: { x: 16, y: 10 },
+      }).setInteractive();
+
+      btn.on("pointerdown", () => this.scene.start("game", { courseKey: key }));
+      y += 70;
+    }
+  }
+}

--- a/src/game/utils/textures.js
+++ b/src/game/utils/textures.js
@@ -1,0 +1,7 @@
+export function makeRectTexture(scene, key, w, h, color) {
+  const g = scene.add.graphics();
+  g.fillStyle(color, 1);
+  g.fillRoundedRect(0, 0, w, h, 6);
+  g.generateTexture(key, w, h);
+  g.destroy();
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,86 +1,12 @@
 import Phaser from "phaser";
-
-class MainScene extends Phaser.Scene {
-  constructor() {
-    super("main");
-  }
-
-  create() {
-    // 背景色
-    this.cameras.main.setBackgroundColor("#87CEEB");
-
-    // 四角形テクスチャ生成（画像素材なしでOK）
-    this.makeRectTexture("ground", 64, 24, 0x2ecc71);
-    this.makeRectTexture("player", 24, 32, 0x2d7ff9);
-
-    // 重力
-    this.physics.world.gravity.y = 1100;
-
-    // 地面（静的）
-    this.platforms = this.physics.add.staticGroup();
-    this.platforms.create(480, 560, "ground").setScale(16, 1).refreshBody(); // 横に長い床
-
-    // プレイヤー
-    this.player = this.physics.add.sprite(120, 480, "player");
-    this.player.setCollideWorldBounds(true);
-    this.player.setDragX(900);         // 慣性を抑える
-    this.player.setMaxVelocity(320, 900);
-
-    // 当たり判定
-    this.physics.add.collider(this.player, this.platforms);
-
-    // 入力
-    this.cursors = this.input.keyboard.createCursorKeys();
-
-    // 画面固定の操作説明
-    const hint = this.add.text(12, 12, "← → 移動 / ↑ ジャンプ", {
-      fontFamily: "system-ui",
-      fontSize: "16px",
-      color: "#0b1b2a",
-      backgroundColor: "rgba(255,255,255,0.7)",
-      padding: { x: 10, y: 6 },
-    });
-    hint.setScrollFactor(0);
-  }
-
-  update() {
-    const accel = 1400;
-
-    // 左右移動
-    if (this.cursors.left.isDown) {
-      this.player.setAccelerationX(-accel);
-    } else if (this.cursors.right.isDown) {
-      this.player.setAccelerationX(accel);
-    } else {
-      this.player.setAccelerationX(0);
-    }
-
-    // ジャンプ（接地時のみ）
-    const onGround =
-      this.player.body.blocked.down || this.player.body.touching.down;
-
-    if (onGround && Phaser.Input.Keyboard.JustDown(this.cursors.up)) {
-      this.player.setVelocityY(-520);
-    }
-  }
-
-  makeRectTexture(key, w, h, color) {
-    const g = this.add.graphics();
-    g.fillStyle(color, 1);
-    g.fillRoundedRect(0, 0, w, h, 6);
-    g.generateTexture(key, w, h);
-    g.destroy();
-  }
-}
+import { MenuScene } from "./game/scenes/MenuScene";
+import { GameScene } from "./game/scenes/GameScene";
+import { ClearScene } from "./game/scenes/ClearScene";
 
 new Phaser.Game({
   type: Phaser.AUTO,
-  width: 960,
-  height: 600,
   parent: "app",
-  physics: {
-    default: "arcade",
-    arcade: { debug: false },
-  },
-  scene: [MainScene],
+  scale: { mode: Phaser.Scale.RESIZE },
+  physics: { default: "arcade", arcade: { debug: false } },
+  scene: [MenuScene, GameScene, ClearScene],
 });


### PR DESCRIPTION
## 概要
Issue #5 の対応として、ゲーム内にコース選択画面を追加し、
テーマの異なる複数コースをプレイできるようにしました。

Scene を増やすのではなく、データ駆動（courses.js）で
コース差分を管理する構成にしています。

---

## 対応内容
- コース選択画面（MenuScene）を実装
- 以下4種類のコースを追加
  - 地上コース
  - 地下コース
  - 水中コース（浮上・潜水操作）
  - 城コース（マグマ即死ギミック）
- コースごとに以下を切り替え
  - 背景色
  - 重力
  - プレイヤー操作感
  - 足場配置
  - ギミック
- ゴール到達時のクリア画面を実装
- 初期スポーン位置を地面基準に修正し、即死を防止

---

## 設計メモ
- GameScene は共通化し、コース差分は `courses.js` で管理
- 画像素材は使わず、Graphics からテクスチャを生成
- 今後のコース追加はデータ定義の追加のみで対応可能

---

## 動作確認
- [x] コース選択画面から各コースへ遷移できる
- [x] 水中コースで浮上・潜水操作が可能
- [x] 城コースでマグマ即死が正しく動作
- [x] 初期スポーン時に即ゲームオーバーにならない
- [x] ゴール到達でクリア画面へ遷移する

---

Closes #5