### PR TITLE
タイトル画面作成#9

### DIFF
--- a/src/game/scenes/TitleScene.js
+++ b/src/game/scenes/TitleScene.js
@@ -1,0 +1,45 @@
+export class TitleScene extends Phaser.Scene {
+  constructor() {
+    super("title");
+  }
+
+  create() {
+    const w = this.scale.width;
+    const h = this.scale.height;
+
+    this.cameras.main.setBackgroundColor("#0b1220");
+
+    // タイトル
+    const title = this.add.text(w / 2, h * 0.28, "Kamashin Brothers", {
+      fontFamily: "system-ui",
+      fontSize: "40px",
+      color: "#ffffff",
+      fontStyle: "bold",
+    });
+    title.setOrigin(0.5);
+
+    // 操作案内
+    const hint = this.add.text(w / 2, h * 0.62, "クリック or Enter でスタート", {
+      fontFamily: "system-ui",
+      fontSize: "22px",
+      color: "#ffffff",
+      backgroundColor: "rgba(255,255,255,0.12)",
+      padding: { x: 16, y: 10 },
+    });
+    hint.setOrigin(0.5);
+
+    // ちょい演出（点滅）
+    this.tweens.add({
+      targets: hint,
+      alpha: 0.25,
+      duration: 700,
+      yoyo: true,
+      repeat: -1,
+    });
+
+    // 入力でメニューへ
+    this.input.once("pointerdown", () => this.scene.start("menu"));
+    this.input.keyboard.once("keydown-ENTER", () => this.scene.start("menu"));
+    this.input.keyboard.once("keydown-SPACE", () => this.scene.start("menu"));
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,5 @@
 import Phaser from "phaser";
+import { TitleScene } from "./game/scenes/TitleScene";
 import { MenuScene } from "./game/scenes/MenuScene";
 import { GameScene } from "./game/scenes/GameScene";
 import { ClearScene } from "./game/scenes/ClearScene";
@@ -8,5 +9,5 @@ new Phaser.Game({
   parent: "app",
   scale: { mode: Phaser.Scale.RESIZE },
   physics: { default: "arcade", arcade: { debug: false } },
-  scene: [MenuScene, GameScene, ClearScene],
+  scene: [TitleScene, MenuScene, GameScene, ClearScene], // ★ Title を追加
 });


### PR DESCRIPTION
## 概要
ゲーム起動時に表示されるタイトル画面を追加しました。
クリック / Enter でコース選択画面へ遷移します。

---

## 対応内容
- TitleScene を新規追加
- 起動時の初期Scene を TitleScene に変更
- クリック / Enter / Space で MenuScene へ遷移

---

## 動作確認
- [x] 起動時にタイトル画面が表示される
- [x] 入力でコース選択画面へ遷移できる
- [x] 既存のゲーム挙動に影響がない

---

Closes #9